### PR TITLE
Added Lab configs as part of DU, moved version routing to app responsibility

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -32,7 +32,7 @@ JENKINS_BUILD_NAME=$JENKINS_DIR/build-name
 mkdir "$JENKINS_DIR"
 
 
-if [ -z "$PRODUCT" ] || [ "$PRODUCT" == "none" ]
+if [ -z ${PRODUCT:-} ] || [ "$PRODUCT" == "none" ]
 then
   echo "Deployer upgrade" >> $JENKINS_BUILD_NAME
   echo "Deployer upgraded. Nothing deployed." >> $JENKINS_DESCRIPTION

--- a/products/mock-ee.conf
+++ b/products/mock-ee.conf
@@ -1,6 +1,6 @@
 DU_ARTIFACT=health-apis-mock-eligibility-and-enrollment-deployment
-DU_VERSION=1.0.9
+DU_VERSION=1.0.10
 DU_NAMESPACE=mee
 DU_DECRYPTION_KEY="$CRYPTO_KEY"
-DU_HEALTH_CHECK_PATH="/mock-ee/v0/actuator/health"
-DU_LOAD_BALANCER_RULES[1]="/mock-ee/v0/*"
+DU_HEALTH_CHECK_PATH="/mock-ee/actuator/health"
+DU_LOAD_BALANCER_RULES[1]="/mock-ee/*"

--- a/products/mock-ee.yaml
+++ b/products/mock-ee.yaml
@@ -24,7 +24,7 @@ spec:
   rules:
     - http:
         paths:
-          - path: /mock-ee/v0/(.*)
+          - path: /mock-ee/(.*)
             backend:
               serviceName: mock-ee
               servicePort: 8082


### PR DESCRIPTION
JIRA Issue: https://vasdvp.atlassian.net/browse/CCE-61

as well as https://vasdvp.atlassian.net/browse/CCE-62

Lab config and test vars added to the deployment unit for Mock-EE.  Deploying to QA first, will have an MR and PR for the actual lab deployment later.

Also, the application has been updated to handle the version part of the path per CCE-62.  The LB & Ingress have been updated to no longer include version information.