### PR TITLE
Task/gp 19 support gal processor

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,7 +92,7 @@ pipeline {
   }
   parameters {
     booleanParam(name: 'DEBUG', defaultValue: false, description: "Enable debugging output")
-    choice(name: 'PRODUCT', choices: ['none','carma','community-care','data-query','exemplar','gal','hotline','mock-ee','prometheus','squares','urgent-care'], description: "Install this product")
+    choice(name: 'PRODUCT', choices: ['none','carma','community-care','data-query','exemplar','gal','gal-processor','hotline','mock-ee','prometheus','squares','urgent-care'], description: "Install this product")
     choice(name: 'AVAILABILITY_ZONES', choices: ['all','us-gov-west-1a','us-gov-west-1b','us-gov-west-1c'], description: "Install into this availability zone")
     booleanParam(name: 'LEAVE_GREEN_ROUTES', defaultValue: false, description: "Leave the green load balancer attached to the last availability zone modified")
     booleanParam(name: 'SIMULATE_REGRESSION_TEST_FAILURE', defaultValue: false, description: "Force rollback logic by simulating a test failure.")

--- a/products/gal-processor.conf
+++ b/products/gal-processor.conf
@@ -3,5 +3,5 @@ DU_VERSION=1.0.0
 DU_NAMESPACE=views-gal-processor
 DU_DECRYPTION_KEY="$DEPLOYMENT_CRYPTO_KEY"
 DU_HEALTH_CHECK_PATH="/gal-processor/actuator/info"
-DU_LOAD_BALANCER_RULES[1]="*/gal-processor/*"
+DU_LOAD_BALANCER_RULES[1]="/gal-processor/*"
 DU_PROPERTY_LEVEL_ENCRYPTION=true

--- a/products/gal-processor.conf
+++ b/products/gal-processor.conf
@@ -1,0 +1,7 @@
+DU_ARTIFACT=gal-processor-deployment
+DU_VERSION=1.0.0
+DU_NAMESPACE=views-gal-processor
+DU_DECRYPTION_KEY="$DEPLOYMENT_CRYPTO_KEY"
+DU_HEALTH_CHECK_PATH="/gal-processor/actuator/info"
+DU_LOAD_BALANCER_RULES[1]="*/gal-processor/*"
+DU_PROPERTY_LEVEL_ENCRYPTION=true

--- a/products/gal-processor.yaml
+++ b/products/gal-processor.yaml
@@ -25,7 +25,7 @@ spec:
   rules:
     - http:
         paths:
-          - path: /gal-processor/(.*)
+          - path: */gal-processor/(.*)
             backend:
-              serviceName: gal-processor-experience
+              serviceName: gal-processor
               servicePort: 8082

--- a/products/gal-processor.yaml
+++ b/products/gal-processor.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: $DU_NAMESPACE
+  labels:
+    deployment-id: $K8S_DEPLOYMENT_ID
+    deployment-unit: $PRODUCT
+    deployment-unit-artifact: $DU_ARTIFACT
+    deployment-unit-version: $DU_VERSION
+    deployment-date: $BUILD_DATE
+    deployment-s3-bucket: $DU_AWS_BUCKET_NAME
+    deployment-s3-folder: $DU_S3_FOLDER
+    deployment-app-version: $GAL_PROCESSOR_VERSION
+    deployment-test-status: UNTESTED
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: views-gal-processor-ingress
+  namespace: $DU_NAMESPACE
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/proxy-next-upstream-tries: "$1"
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /gal-processor/(.*)
+            backend:
+              serviceName: gal-processor-experience
+              servicePort: 8082


### PR DESCRIPTION
Gal Processor is a new Java app being developed to replace the Mule GAL project. This is only going to be deployed to QA for initial testing, where the Mule GAL apps are not allowed to exist long term. Normally their LB rule (\*/gal\*) would gobble up the requests meant for this, but everything should be fine since those aren't regularly deployed to QA. 

If I misunderstood something let me know 