### PR TITLE
Enforce cpu/mem limits for GAL

### DIFF
--- a/products/gal.yaml
+++ b/products/gal.yaml
@@ -29,3 +29,13 @@ spec:
             backend:
               serviceName: gal-experience
               servicePort: 8082
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: views-gal-resource-quota
+  namespace: $DU_NAMESPACE
+spec:
+  hard:
+    limits.cpu: "1000m"
+    limits.memory: "6Gi"

--- a/products/gal.yaml
+++ b/products/gal.yaml
@@ -37,5 +37,5 @@ metadata:
   namespace: $DU_NAMESPACE
 spec:
   hard:
-    limits.cpu: "1000m"
-    limits.memory: "6Gi"
+    limits.cpu: "1500m"
+    limits.memory: "9Gi"


### PR DESCRIPTION
**ResourceQuota**
CPU: 1 Core
Memory: 6 GB

Note: Temporarily deploy GAL with a ResourceQuota successfully to QA, test and verify, then finally remove GAL from QA.