### PR TITLE
Fix GAL Memory Quota

### DIFF
--- a/products/gal.yaml
+++ b/products/gal.yaml
@@ -38,4 +38,4 @@ metadata:
 spec:
   hard:
     limits.cpu: "1500m"
-    limits.memory: "9Gi"
+    limits.memory: "9G"


### PR DESCRIPTION
Use correct unit for denoting gigabyte: `G` vs `Gi`
