### PR TITLE
Increased CCE CPU Limit 

### DIFF
--- a/products/community-care.yaml
+++ b/products/community-care.yaml
@@ -38,5 +38,5 @@ metadata:
   namespace: $DU_NAMESPACE
 spec:
   hard:
-    limits.cpu: "150m"
+    limits.cpu: "6000m"
     limits.memory: "5.5G"


### PR DESCRIPTION
This increase is based on the observed usage required for successfully starting up applications in CCE.

**Before**: 0.15 Cores
**After**: 6 Cores 

(1 Core for Community Care + 1 Core for Kong) x 3 replicas
