### PR TITLE
Increase CCE memory quota

### DIFF
--- a/products/community-care.yaml
+++ b/products/community-care.yaml
@@ -39,4 +39,4 @@ metadata:
 spec:
   hard:
     limits.cpu: "6000m"
-    limits.memory: "5.5G"
+    limits.memory: "9G"


### PR DESCRIPTION
Increasing CCE memory quota based on observed restarts of Kong from hitting its memory limit.

**Before**
Memory: 5.5 GB

**After**
Memory: 9 GB

Breakdown: (community-care pod 2GB x 3 replicas) + (kong pod 1GB x 3 replicas) = 9 GB