### PR TITLE
X/car 000 integrate carma fms connector

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,7 +92,7 @@ pipeline {
   }
   parameters {
     booleanParam(name: 'DEBUG', defaultValue: false, description: "Enable debugging output")
-    choice(name: 'PRODUCT', choices: ['none','carma','community-care','data-query','exemplar','gal','gal-processor','hotline','mock-ee','monitoring','squares','urgent-care'], description: "Install this product")
+    choice(name: 'PRODUCT', choices: ['none','carma','carma-fms-connector','community-care','data-query','exemplar','gal','gal-processor','hotline','mock-ee','monitoring','squares','urgent-care'], description: "Install this product")
     choice(name: 'AVAILABILITY_ZONES', choices: ['all','us-gov-west-1a','us-gov-west-1b','us-gov-west-1c'], description: "Install into this availability zone")
     booleanParam(name: 'LEAVE_GREEN_ROUTES', defaultValue: false, description: "Leave the green load balancer attached to the last availability zone modified")
     booleanParam(name: 'SIMULATE_REGRESSION_TEST_FAILURE', defaultValue: false, description: "Force rollback logic by simulating a test failure.")

--- a/products/carma-fms-connector.conf
+++ b/products/carma-fms-connector.conf
@@ -1,6 +1,6 @@
 DU_ARTIFACT=health-apis-carma-fms-connector-deployment
 DU_VERSION=1.0.3
-DU_NAMESPACE=carma-fc
+DU_NAMESPACE=carma-fms
 DU_DECRYPTION_KEY="$DEPLOYMENT_CRYPTO_KEY"
 DU_HEALTH_CHECK_PATH="/api/carma-fms/actuator/health"
 DU_LOAD_BALANCER_RULES[1]="*/carma-fms/*"

--- a/products/carma-fms-connector.conf
+++ b/products/carma-fms-connector.conf
@@ -1,7 +1,7 @@
 DU_ARTIFACT=health-apis-carma-fms-connector-deployment
-DU_VERSION=1.0.3
+DU_VERSION=1.0.4
 DU_NAMESPACE=carma-fms
 DU_DECRYPTION_KEY="$DEPLOYMENT_CRYPTO_KEY"
-DU_HEALTH_CHECK_PATH="/api/carma-fms/actuator/health"
-DU_LOAD_BALANCER_RULES[1]="*/carma-fms/*"
+DU_HEALTH_CHECK_PATH="/carma-fms/v0/actuator/health"
+DU_LOAD_BALANCER_RULES[1]="/carma-fms/v0/*"
 DU_PROPERTY_LEVEL_ENCRYPTION=true

--- a/products/carma-fms-connector.conf
+++ b/products/carma-fms-connector.conf
@@ -1,0 +1,7 @@
+DU_ARTIFACT=health-apis-carma-fms-connector-deployment
+DU_VERSION=1.0.0
+DU_NAMESPACE=carma-fc
+DU_DECRYPTION_KEY="$DEPLOYMENT_CRYPTO_KEY"
+DU_HEALTH_CHECK_PATH="/api/carma-fms/actuator/health"
+DU_LOAD_BALANCER_RULES[1]="*/carma-fms/*"
+DU_PROPERTY_LEVEL_ENCRYPTION=true

--- a/products/carma-fms-connector.conf
+++ b/products/carma-fms-connector.conf
@@ -1,5 +1,5 @@
 DU_ARTIFACT=health-apis-carma-fms-connector-deployment
-DU_VERSION=1.0.0
+DU_VERSION=1.0.3
 DU_NAMESPACE=carma-fc
 DU_DECRYPTION_KEY="$DEPLOYMENT_CRYPTO_KEY"
 DU_HEALTH_CHECK_PATH="/api/carma-fms/actuator/health"

--- a/products/carma-fms-connector.yaml
+++ b/products/carma-fms-connector.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: $DU_NAMESPACE
+  labels:
+    deployment-id: $K8S_DEPLOYMENT_ID
+    deployment-unit: $PRODUCT
+    deployment-unit-artifact: $DU_ARTIFACT
+    deployment-unit-version: $DU_VERSION
+    deployment-date: $BUILD_DATE
+    deployment-s3-bucket: $DU_AWS_BUCKET_NAME
+    deployment-s3-folder: $DU_S3_FOLDER
+    deployment-app-version: $CFC_VERSION
+    deployment-test-status: UNTESTED
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: carma-fms-connector-ingress
+  namespace: $DU_NAMESPACE
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /(api/)?carma-fms(.*)
+            backend:
+              serviceName: carma-fms-connector
+              servicePort: 80

--- a/products/carma-fms-connector.yaml
+++ b/products/carma-fms-connector.yaml
@@ -24,7 +24,7 @@ spec:
   rules:
     - http:
         paths:
-          - path: /(api/)?carma-fms(.*)
+          - path: /carma-fms/v0/(.*)
             backend:
               serviceName: carma-fms-connector
               servicePort: 80


### PR DESCRIPTION
This PR is for integrating the new CARMA Phase 2 component, the carma-fms-connector.

This is primarily a scheduled task job, but also has developer use endpoints to manually kick off a job in case an unscheduled run is required.

Reopening PR.  Below feedback has been addressed.

> The leading /api in the ingress path is a hold over from Mule dev days and isn't required for pure Java implementations. The API controller methods will be updated to listen on plain / and the ALB/Ingress level will map the /carma-fms/v0/* to /* in the application pod.