### PR TITLE
Removing AWS Credentials to test EC2 role

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:latest
+FROM centos:7
 
 RUN yum update -yqq \
     && yum install -yqq yum-utils \
@@ -17,7 +17,7 @@ RUN curl -skLo /usr/local/bin/jq https://github.com/stedolan/jq/releases/downloa
 #
 # Docker
 #
-RUN yum -y install https://download.docker.com/linux/centos/7/x86_64/stable/Packages/containerd.io-1.2.6-3.3.el7.x86_64.rpm
+#RUN yum -y install https://download.docker.com/linux/centos/7/x86_64/stable/Packages/containerd.io-1.2.6-3.3.el7.x86_64.rpm
 RUN curl -fskLS https://get.docker.com | sh
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ RUN curl -skLo /usr/local/bin/jq https://github.com/stedolan/jq/releases/downloa
 #
 # Docker
 #
-RUN curl -fskL https://get.docker.com | sh
+RUN yum -y install https://download.docke r.com/linux/centos/7/x86_64/stable/Packages/containerd.io-1.2.6-3.3.el7.x86_64.rpm
+RUN curl -fskLS https://get.docker.com | sh
 
 
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ RUN curl -skLo /usr/local/bin/jq https://github.com/stedolan/jq/releases/downloa
 #
 # Docker
 #
-#RUN yum -y install https://download.docker.com/linux/centos/7/x86_64/stable/Packages/containerd.io-1.2.6-3.3.el7.x86_64.rpm
 RUN curl -fskLS https://get.docker.com | sh
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM centos:7
 
 RUN yum update -yqq \
-    && yum install -yqq yum-utils \
-    && yum install -yqq gettext openssh-clients git \
-    && yum install -yqq zip unzip \
-    && yum install -yqq dos2unix \
+    && yum install -y -q yum-utils \
+    && yum install -y -q gettext openssh-clients git \
+    && yum install -y -q zip unzip \
+    && yum install -y -q dos2unix \
     && yum clean all
 
 #
@@ -45,4 +45,4 @@ RUN curl -fsSL https://get.docker.com | sh
 #
 # Odd... this yum command succeeds down here at the bottom, but fails at the top.
 #
-RUN yum install -yqq openssl
+RUN yum install -y -q openssl

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN curl -skLo /usr/local/bin/jq https://github.com/stedolan/jq/releases/downloa
 #
 # Docker
 #
-RUN yum -y install https://download.docke r.com/linux/centos/7/x86_64/stable/Packages/containerd.io-1.2.6-3.3.el7.x86_64.rpm
+RUN yum -y install https://download.docker.com/linux/centos/7/x86_64/stable/Packages/containerd.io-1.2.6-3.3.el7.x86_64.rpm
 RUN curl -fskLS https://get.docker.com | sh
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN curl -skLo /usr/local/bin/jq https://github.com/stedolan/jq/releases/downloa
 #
 # Docker
 #
-#RUN curl -fskLS https://get.docker.com | sh
+RUN curl -fskL https://get.docker.com | sh
 
 
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN curl -skLo /usr/local/bin/jq https://github.com/stedolan/jq/releases/downloa
 #
 # Docker
 #
-RUN curl -fskLS https://get.docker.com | sh
+#RUN curl -fskLS https://get.docker.com | sh
 
 
 #

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,12 +15,6 @@ def saunter(scriptName) {
     string(
       credentialsId: 'DOCKER_SOURCE_REGISTRY',
       variable: 'DOCKER_SOURCE_REGISTRY'),
-/*    string(
-      credentialsId: 'APP_CONFIG_AWS_ACCESS_KEY_ID',
-      variable: 'AWS_ACCESS_KEY_ID'),
-    string(
-      credentialsId: 'APP_CONFIG_AWS_SECRET_ACCESS_KEY',
-      variable: 'AWS_SECRET_ACCESS_KEY'), */
     string(
       credentialsId: 'CRYPTO_KEY',
       variable: 'CRYPTO_KEY'),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,12 +15,12 @@ def saunter(scriptName) {
     string(
       credentialsId: 'DOCKER_SOURCE_REGISTRY',
       variable: 'DOCKER_SOURCE_REGISTRY'),
-    string(
+/*    string(
       credentialsId: 'APP_CONFIG_AWS_ACCESS_KEY_ID',
       variable: 'AWS_ACCESS_KEY_ID'),
     string(
       credentialsId: 'APP_CONFIG_AWS_SECRET_ACCESS_KEY',
-      variable: 'AWS_SECRET_ACCESS_KEY'),
+      variable: 'AWS_SECRET_ACCESS_KEY'), */
     string(
       credentialsId: 'CRYPTO_KEY',
       variable: 'CRYPTO_KEY'),

--- a/deployment-unit.md
+++ b/deployment-unit.md
@@ -100,12 +100,6 @@ also be set.
 > Environment-specific S3 buckets will be used to house deployment-specific folders.
 > The following environment variables will be provided for substitution in your files.
 >
-> `DU_AWS_ACCESS_KEY_ID`
-> The AWS access key ID to access the s3 bucket
->
-> `DU_AWS_SECRET_ACCESS_KEY`
-> The AWS access key secret to access the s3 bucket
->
 > `DU_AWS_BUCKET_NAME`
 > The environment specific bucket name
 >

--- a/environments/lab.conf
+++ b/environments/lab.conf
@@ -5,5 +5,3 @@ export BLUE_LOAD_BALANCER=internal-blue-lab-kubernetes-875337103.us-gov-west-1.e
 export ROLLBACK_ON_TEST_FAILURES=true
 export VPC_NAME=Lab
 export DU_AWS_BUCKET_NAME=app-config-storage-lab
-export DU_AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID"
-export DU_AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY"

--- a/environments/production.conf
+++ b/environments/production.conf
@@ -5,5 +5,3 @@ export BLUE_LOAD_BALANCER=internal-blue-production-kubernetes-1292928823.us-gov-
 export ROLLBACK_ON_TEST_FAILURES=true
 export VPC_NAME=Production
 export DU_AWS_BUCKET_NAME=app-config-storage-prod
-export DU_AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID"
-export DU_AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY"

--- a/environments/qa.conf
+++ b/environments/qa.conf
@@ -5,5 +5,3 @@ export BLUE_LOAD_BALANCER=internal-blue-qa-kubernetes-369303548.us-gov-west-1.el
 export ROLLBACK_ON_TEST_FAILURES=false
 export VPC_NAME=QA
 export DU_AWS_BUCKET_NAME=app-config-storage-qa
-#export DU_AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID"
-#export DU_AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY"

--- a/environments/qa.conf
+++ b/environments/qa.conf
@@ -5,5 +5,5 @@ export BLUE_LOAD_BALANCER=internal-blue-qa-kubernetes-369303548.us-gov-west-1.el
 export ROLLBACK_ON_TEST_FAILURES=false
 export VPC_NAME=QA
 export DU_AWS_BUCKET_NAME=app-config-storage-qa
-export DU_AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID"
-export DU_AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY"
+#export DU_AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID"
+#export DU_AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY"

--- a/environments/staging-lab.conf
+++ b/environments/staging-lab.conf
@@ -6,5 +6,3 @@ export BLUE_LOAD_BALANCER=blue.staging-lab.lighthouse.va.gov
 export ROLLBACK_ON_TEST_FAILURES=true
 export VPC_NAME=Staging-Lab
 export DU_AWS_BUCKET_NAME=app-config-storage-staging-lab
-export DU_AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID"
-export DU_AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY"

--- a/environments/staging.conf
+++ b/environments/staging.conf
@@ -5,5 +5,3 @@ export BLUE_LOAD_BALANCER=internal-blue-staging-kubernetes-1216288547.us-gov-wes
 export ROLLBACK_ON_TEST_FAILURES=true
 export VPC_NAME=Staging
 export DU_AWS_BUCKET_NAME=app-config-storage-staging
-export DU_AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID"
-export DU_AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY"

--- a/environments/uat.conf
+++ b/environments/uat.conf
@@ -5,5 +5,3 @@ export BLUE_LOAD_BALANCER=internal-blue-uat-kubernetes-2073437472.us-gov-west-1.
 export ROLLBACK_ON_TEST_FAILURES=true
 export VPC_NAME=UAT
 export DU_AWS_BUCKET_NAME=app-config-storage-uat
-export DU_AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID"
-export DU_AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY"

--- a/products/data-query.conf
+++ b/products/data-query.conf
@@ -1,5 +1,5 @@
 DU_ARTIFACT=health-apis-data-query-deployment
-DU_VERSION=1.0.255
+DU_VERSION=1.0.272
 DU_NAMESPACE=dq
 DU_DECRYPTION_KEY="$DEPLOYMENT_CRYPTO_KEY"
 DU_HEALTH_CHECK_PATH="/fhir/v0/dstu2/actuator/health"

--- a/products/data-query.conf
+++ b/products/data-query.conf
@@ -1,5 +1,5 @@
 DU_ARTIFACT=health-apis-data-query-deployment
-DU_VERSION=1.0.272
+DU_VERSION=1.0.277
 DU_NAMESPACE=dq
 DU_DECRYPTION_KEY="$DEPLOYMENT_CRYPTO_KEY"
 DU_HEALTH_CHECK_PATH="/fhir/v0/dstu2/actuator/health"

--- a/products/gal-processor.conf
+++ b/products/gal-processor.conf
@@ -1,5 +1,5 @@
 DU_ARTIFACT=health-apis-gal-processor-deployment
-DU_VERSION=1.0.20
+DU_VERSION=1.0.21
 DU_NAMESPACE=views-gal-processor
 DU_DECRYPTION_KEY="$DEPLOYMENT_CRYPTO_KEY"
 DU_HEALTH_CHECK_PATH="/gal-processor/actuator/health"

--- a/products/gal-processor.conf
+++ b/products/gal-processor.conf
@@ -1,5 +1,5 @@
 DU_ARTIFACT=health-apis-gal-processor-deployment
-DU_VERSION=1.0.18
+DU_VERSION=1.0.20
 DU_NAMESPACE=views-gal-processor
 DU_DECRYPTION_KEY="$DEPLOYMENT_CRYPTO_KEY"
 DU_HEALTH_CHECK_PATH="/gal-processor/actuator/health"

--- a/products/gal-processor.conf
+++ b/products/gal-processor.conf
@@ -1,5 +1,5 @@
 DU_ARTIFACT=health-apis-gal-processor-deployment
-DU_VERSION=1.0.21
+DU_VERSION=1.0.25
 DU_NAMESPACE=views-gal-processor
 DU_DECRYPTION_KEY="$DEPLOYMENT_CRYPTO_KEY"
 DU_HEALTH_CHECK_PATH="/gal-processor/actuator/health"

--- a/products/urgent-care.conf
+++ b/products/urgent-care.conf
@@ -1,5 +1,5 @@
 DU_ARTIFACT=health-apis-urgent-care-deployment
-DU_VERSION=1.0.57
+DU_VERSION=1.0.58
 DU_NAMESPACE=uc
 DU_DECRYPTION_KEY="$DEPLOYMENT_CRYPTO_KEY"
 DU_HEALTH_CHECK_PATH="/fhir/v0/r4/actuator/health"

--- a/products/urgent-care.conf
+++ b/products/urgent-care.conf
@@ -1,5 +1,5 @@
 DU_ARTIFACT=health-apis-urgent-care-deployment
-DU_VERSION=1.0.58
+DU_VERSION=1.0.63
 DU_NAMESPACE=uc
 DU_DECRYPTION_KEY="$DEPLOYMENT_CRYPTO_KEY"
 DU_HEALTH_CHECK_PATH="/fhir/v0/r4/actuator/health"

--- a/products/urgent-care.conf
+++ b/products/urgent-care.conf
@@ -1,5 +1,5 @@
 DU_ARTIFACT=health-apis-urgent-care-deployment
-DU_VERSION=1.0.55
+DU_VERSION=1.0.57
 DU_NAMESPACE=uc
 DU_DECRYPTION_KEY="$DEPLOYMENT_CRYPTO_KEY"
 DU_HEALTH_CHECK_PATH="/fhir/v0/r4/actuator/health"

--- a/products/urgent-care.conf
+++ b/products/urgent-care.conf
@@ -1,5 +1,5 @@
 DU_ARTIFACT=health-apis-urgent-care-deployment
-DU_VERSION=1.0.57
+DU_VERSION=1.0.55
 DU_NAMESPACE=uc
 DU_DECRYPTION_KEY="$DEPLOYMENT_CRYPTO_KEY"
 DU_HEALTH_CHECK_PATH="/fhir/v0/r4/actuator/health"


### PR DESCRIPTION
Jenkles is now using the EC2 role 'project-devtools-role'. The AWS credentials have been commented out for all users on the instance and removed from the Jenkinsfile for the QA Deployer. Testing deployments.