### PR TITLE
updated Target Group Health Checks for Hotline and Squares

### DIFF
--- a/products/hotline.conf
+++ b/products/hotline.conf
@@ -1,8 +1,9 @@
+# HOTLINE Deployment Unit Configurations
 DU_ARTIFACT=health-apis-hotline-deployment
 DU_VERSION=1.0.21
 DU_NAMESPACE=views-hotline
 DU_DECRYPTION_KEY="$DEPLOYMENT_CRYPTO_KEY"
-DU_HEALTH_CHECK_PATH="/patsr/healthz"
+DU_HEALTH_CHECK_PATH="/patsr/whHotlineCase/healthz"
 DU_LOAD_BALANCER_RULES[1]="*/patsr/*"
 DU_LOAD_BALANCER_RULES[2]="*/sfdc/*"
 DU_LOAD_BALANCER_RULES[3]="*/vimt/*"

--- a/products/squares.conf
+++ b/products/squares.conf
@@ -3,6 +3,6 @@ DU_ARTIFACT=health-apis-squares-deployment
 DU_VERSION=1.0.22
 DU_NAMESPACE=views-squares
 DU_DECRYPTION_KEY="$DEPLOYMENT_CRYPTO_KEY"
-DU_HEALTH_CHECK_PATH="/squares/healthz"
+DU_HEALTH_CHECK_PATH="/squares/mvi/healthz"
 DU_LOAD_BALANCER_RULES[1]="*/squares/*"
 DU_PROPERTY_LEVEL_ENCRYPTION=true


### PR DESCRIPTION
The issue with the old health check is it was JUST the experience.  So when AZ B went down last night the experience calls were still working?  Because the workers would respond on the first call.  But they couldn't talk between themselves.

These new health checks will test communication within the cluster which is closer to the correct answer...