### PR TITLE
Add ingress and uc namespace NetworkPolicies to urgent-care yaml

### DIFF
--- a/products/urgent-care.yaml
+++ b/products/urgent-care.yaml
@@ -46,29 +46,29 @@ kind: NetworkPolicy
 metadata:
   name: urgent-care-network-policy
   namespace: $DU_NAMESPACE
-  spec:
-    podSelector: {}
-    policyTypes:
-    - Ingress
-    ingress:
-    - from:
-      - podSelector: {}
-      - namespaceSelector:
-          matchLabels:
-            deployment-unit: $PRODUCT
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+    - namespaceSelector:
+        matchLabels:
+          deployment-unit: $PRODUCT
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: ingress-network-policy
   namespace: $DU_NAMESPACE
-  spec:
-    podSelector: {}
-    policyTypes:
-    - Ingress
-    ingress:
-    - from:
-      - podSelector: {}
-      - namespaceSelector:
-          matchLabels:
-            app.kubernetes.io/name: ingress-nginx
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+    - namespaceSelector:
+        matchLabels:
+          app.kubernetes.io/name: ingress-nginx

--- a/products/urgent-care.yaml
+++ b/products/urgent-care.yaml
@@ -40,3 +40,35 @@ spec:
   hard:
     limits.cpu: "4500m"
     limits.memory: "12G"
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: urgent-care-network-policy
+  namespace: $DU_NAMESPACE
+  spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+    - namespaceSelector:
+        matchLabels:
+          deployment-unit: $PRODUCT
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ingress-network-policy
+  namespace: $DU_NAMESPACE
+  spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}
+    - namespaceSelector:
+        matchLabels:
+          app.kubernetes.io/name: ingress-nginx

--- a/products/urgent-care.yaml
+++ b/products/urgent-care.yaml
@@ -47,15 +47,15 @@ metadata:
   name: urgent-care-network-policy
   namespace: $DU_NAMESPACE
   spec:
-  podSelector: {}
-  policyTypes:
-  - Ingress
-  ingress:
-  - from:
-    - podSelector: {}
-    - namespaceSelector:
-        matchLabels:
-          deployment-unit: $PRODUCT
+    podSelector: {}
+    policyTypes:
+    - Ingress
+    ingress:
+    - from:
+      - podSelector: {}
+      - namespaceSelector:
+          matchLabels:
+            deployment-unit: $PRODUCT
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -63,12 +63,12 @@ metadata:
   name: ingress-network-policy
   namespace: $DU_NAMESPACE
   spec:
-  podSelector: {}
-  policyTypes:
-  - Ingress
-  ingress:
-  - from:
-    - podSelector: {}
-    - namespaceSelector:
-        matchLabels:
-          app.kubernetes.io/name: ingress-nginx
+    podSelector: {}
+    policyTypes:
+    - Ingress
+    ingress:
+    - from:
+      - podSelector: {}
+      - namespaceSelector:
+          matchLabels:
+            app.kubernetes.io/name: ingress-nginx


### PR DESCRIPTION
Using NetworkPolicies in the urgent-care.yaml, enforce namespace isolation such that pods in the uc namespace may only receive traffic from other pods within the same namespace or pods within the ingress namespace.
related story: https://vasdvp.atlassian.net/browse/PIV-23