### PR TITLE
Task/shank 119 capture groups

### DIFF
--- a/products/data-query.yaml
+++ b/products/data-query.yaml
@@ -21,12 +21,12 @@ metadata:
   namespace: $DU_NAMESPACE
   annotations:
     kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/rewrite-target: /dstu2/$1
 spec:
   rules:
     - http:
         paths:
-          - path: /fhir/v0/dstu2/?(.*)
+          - path: /fhir/v0/dstu2/(.*)
             backend:
               serviceName: health-apis-kong
               servicePort: 8082
@@ -38,12 +38,12 @@ metadata:
   namespace: $DU_NAMESPACE
   annotations:
     kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/rewrite-target: /argonaut/data-query/$1
 spec:
   rules:
     - http:
         paths:
-          - path: /fhir/v0/argonaut/data-query/?(.*)
+          - path: /fhir/v0/argonaut/data-query/(.*)
             backend:
               serviceName: health-apis-kong
               servicePort: 8082
@@ -51,16 +51,16 @@ spec:
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: data-query-legacy-ingress
+  name: fhir-version-agnostic-ingress
   namespace: $DU_NAMESPACE
   annotations:
     kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/rewrite-target: /$1$2
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
 spec:
   rules:
     - http:
         paths:
-          - path: /api/(.well-known|AllergyIntolerance|Appointment|Condition|DiagnosticReport|Encounter|Immunization|Location|Medication|MedicationDispense|MedicationOrder|MedicationStatement|metadata|Observation|openapi.json|Organization|Patient|Practitioner|Procedure)(.*)
+          - path: /fhir/v0/(dstu2|argonaut/data-query)/(token|\.well-known)
             backend:
               serviceName: health-apis-kong
               servicePort: 8082

--- a/products/data-query.yaml
+++ b/products/data-query.yaml
@@ -13,6 +13,16 @@ metadata:
     deployment-s3-folder: $DU_S3_FOLDER
     deployment-app-version: $DQ_VERSION
     deployment-test-status: UNTESTED
+#---
+#apiVersion: v1
+#kind: ResourceQuota
+#metadata:
+#  name: data-query-resource-quota
+#  namespace: $DU_NAMESPACE
+#spec:
+#  hard:
+#    limits.cpu: "7800m"
+#    limits.memory: "15G"
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress
@@ -38,7 +48,7 @@ metadata:
   namespace: $DU_NAMESPACE
   annotations:
     kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/rewrite-target: /argonaut/data-query/$1
+    nginx.ingress.kubernetes.io/rewrite-target: /dstu2/$1
 spec:
   rules:
     - http:
@@ -81,13 +91,3 @@ spec:
             backend:
               serviceName: health-apis-kong
               servicePort: 8082
-#---
-#apiVersion: v1
-#kind: ResourceQuota
-#metadata:
-#  name: data-query-resource-quota
-#  namespace: $DU_NAMESPACE
-#spec:
-#  hard:
-#    limits.cpu: "7800m"
-#    limits.memory: "15G"


### PR DESCRIPTION
[SHANK-119](https://vasdvp.atlassian.net/browse/SHANK-119)

* Remove legacy api path
* Create resource agnostic ingress for resources that dont depend on fhir versions
* Update capture groups to pass fhir version to kong on external paths