### PR TITLE
adding product dmc-vet-search

### DIFF
--- a/products/dmc-vet-search.conf
+++ b/products/dmc-vet-search.conf
@@ -1,0 +1,7 @@
+DU_ARTIFACT=health-apis-dmc-vet-search-deployment
+DU_VERSION=1.0.0
+DU_NAMESPACE=dmc-vet-search
+DU_DECRYPTION_KEY="$DEPLOYMENT_CRYPTO_KEY"
+DU_HEALTH_CHECK_PATH="/dmc-vet-search/v0/actuator/info"
+DU_LOAD_BALANCER_RULES[1]="/dmc-vet-search/v0/*"
+DU_PROPERTY_LEVEL_ENCRYPTION=true

--- a/products/dmc-vet-search.yaml
+++ b/products/dmc-vet-search.yaml
@@ -10,7 +10,7 @@ metadata:
     deployment-date: $BUILD_DATE
     deployment-s3-bucket: $DU_AWS_BUCKET_NAME
     deployment-s3-folder: $DU_S3_FOLDER
-    deployment-app-version: $DVS_VERSION
+    deployment-app-version: $DMCS_VERSION
     deployment-test-status: UNTESTED
 ---
 apiVersion: extensions/v1beta1

--- a/products/dmc-vet-search.yaml
+++ b/products/dmc-vet-search.yaml
@@ -10,7 +10,7 @@ metadata:
     deployment-date: $BUILD_DATE
     deployment-s3-bucket: $DU_AWS_BUCKET_NAME
     deployment-s3-folder: $DU_S3_FOLDER
-    deployment-app-version: $CFC_VERSION
+    deployment-app-version: $DVS_VERSION
     deployment-test-status: UNTESTED
 ---
 apiVersion: extensions/v1beta1

--- a/products/dmc-vet-search.yaml
+++ b/products/dmc-vet-search.yaml
@@ -33,7 +33,7 @@ spec:
 apiVersion: v1
 kind: ResourceQuota
 metadata:
-  name: carma-fms-resource-quota
+  name: dmc-vet-search-resource-quota
   namespace: $DU_NAMESPACE
 spec:
   hard:

--- a/products/dmc-vet-search.yaml
+++ b/products/dmc-vet-search.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: $DU_NAMESPACE
+  labels:
+    deployment-id: $K8S_DEPLOYMENT_ID
+    deployment-unit: $PRODUCT
+    deployment-unit-artifact: $DU_ARTIFACT
+    deployment-unit-version: $DU_VERSION
+    deployment-date: $BUILD_DATE
+    deployment-s3-bucket: $DU_AWS_BUCKET_NAME
+    deployment-s3-folder: $DU_S3_FOLDER
+    deployment-app-version: $CFC_VERSION
+    deployment-test-status: UNTESTED
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: dmc-vet-search-ingress
+  namespace: $DU_NAMESPACE
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /dmc-vet-search/v0/(.*)
+            backend:
+              serviceName: dmc-vet-search
+              servicePort: 80
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: carma-fms-resource-quota
+  namespace: $DU_NAMESPACE
+spec:
+  hard:
+    limits.cpu: "600m"
+    limits.memory: "2G"

--- a/products/dmc-vet-search.yaml
+++ b/products/dmc-vet-search.yaml
@@ -38,4 +38,4 @@ metadata:
 spec:
   hard:
     limits.cpu: "1800m"
-    limits.memory: "2G"
+    limits.memory: "6G"

--- a/products/dmc-vet-search.yaml
+++ b/products/dmc-vet-search.yaml
@@ -37,5 +37,5 @@ metadata:
   namespace: $DU_NAMESPACE
 spec:
   hard:
-    limits.cpu: "600m"
+    limits.cpu: "1800m"
     limits.memory: "2G"


### PR DESCRIPTION
This PR adds the product `dmc-vet-search` to the deployer.

The `dmc-vet-search` app is very much like `carma-search` in that it is able to search MVI  and other VA endpoints for veteran demographic and identity information.