### PR TITLE
Added email-to-case configuration.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,7 +89,7 @@ pipeline {
   }
   parameters {
     booleanParam(name: 'DEBUG', defaultValue: false, description: "Enable debugging output")
-    choice(name: 'PRODUCT', choices: ['none','bulk-fhir','carma','carma-fms-connector','community-care','data-query','dmc-vet-search','exemplar','gal','gal-processor','hotline','logging','mock-ee', 'mock-vler','monitoring','provider-directory','squares','urgent-care'], description: "Install this product")
+    choice(name: 'PRODUCT', choices: ['none','bulk-fhir','carma','carma-fms-connector','community-care','data-query','dmc-vet-search','email-to-case','exemplar','gal','gal-processor','hotline','logging','mock-ee', 'mock-vler','monitoring','provider-directory','squares','urgent-care'], description: "Install this product")
     choice(name: 'AVAILABILITY_ZONES', choices: ['all','us-gov-west-1a','us-gov-west-1b','us-gov-west-1c'], description: "Install into this availability zone")
     booleanParam(name: 'DONT_REATTACH_TO_BLUE', defaultValue: false, description: "Leave the load balancer routes and targets attached to green and dont put them back on blue(only available when deploying to a single AZ).")
     booleanParam(name: 'SIMULATE_REGRESSION_TEST_FAILURE', defaultValue: false, description: "Force rollback logic by simulating a test failure.")

--- a/products/email-to-case.conf
+++ b/products/email-to-case.conf
@@ -1,0 +1,7 @@
+DU_ARTIFACT=health-apis-email-to-case-deployment
+DU_VERSION=1.0.2
+DU_NAMESPACE=email-to-case
+DU_DECRYPTION_KEY="$DEPLOYMENT_CRYPTO_KEY"
+DU_HEALTH_CHECK_PATH="/email-to-case/v0/actuator/health"
+DU_LOAD_BALANCER_RULES[1]="/email-to-case/v0/*"
+DU_PROPERTY_LEVEL_ENCRYPTION=true

--- a/products/email-to-case.conf
+++ b/products/email-to-case.conf
@@ -1,5 +1,5 @@
 DU_ARTIFACT=health-apis-email-to-case-deployment
-DU_VERSION=1.0.2
+DU_VERSION=1.0.4
 DU_NAMESPACE=email-to-case
 DU_DECRYPTION_KEY="$DEPLOYMENT_CRYPTO_KEY"
 DU_HEALTH_CHECK_PATH="/email-to-case/v0/actuator/health"

--- a/products/email-to-case.yaml
+++ b/products/email-to-case.yaml
@@ -37,5 +37,5 @@ metadata:
   namespace: $DU_NAMESPACE
 spec:
   hard:
-    limits.cpu: "600m"
-    limits.memory: "2G"
+    limits.cpu: "300m"
+    limits.memory: "1G"

--- a/products/email-to-case.yaml
+++ b/products/email-to-case.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: $DU_NAMESPACE
+  labels:
+    deployment-id: $K8S_DEPLOYMENT_ID
+    deployment-unit: $PRODUCT
+    deployment-unit-artifact: $DU_ARTIFACT
+    deployment-unit-version: $DU_VERSION
+    deployment-date: $BUILD_DATE
+    deployment-s3-bucket: $DU_AWS_BUCKET_NAME
+    deployment-s3-folder: $DU_S3_FOLDER
+    deployment-app-version: $ETC_VERSION
+    deployment-test-status: UNTESTED
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: email-to-case-ingress
+  namespace: $DU_NAMESPACE
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /email-to-case/v0/(.*)
+            backend:
+              serviceName: email-to-case
+              servicePort: 80
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: email-to-case-quota
+  namespace: $DU_NAMESPACE
+spec:
+  hard:
+    limits.cpu: "600m"
+    limits.memory: "2G"


### PR DESCRIPTION
This PR adds support for `email-to-case` in the deployer.

The application, email-to-case, falls under VIEWS development to monitor and process a list of configured mailboxes, creating corresponding Salesforce Case records.  Also included are several REST endpoints for monitoring that processing and the current configuration.

For resource utilization limits, I originally utilized carma-fms as a template, but was able to reduce the limits after Monica monitored in Grafana.  I also previously confirmed the `/email-to-case/v0` with the Devops team.