### PR TITLE
Increased hotline resource quota to support hpa

### DIFF
--- a/products/hotline.yaml
+++ b/products/hotline.yaml
@@ -36,5 +36,5 @@ metadata:
   namespace: $DU_NAMESPACE
 spec:
   hard:
-    limits.cpu: "7500m"
-    limits.memory: "20G"
+    limits.cpu: "15000m"
+    limits.memory: "40G"


### PR DESCRIPTION
Increased cpu/memory quota to support scaling out to max of 4 replicas under load stress.

Should be merged **before** https://github.com/department-of-veterans-affairs/health-apis-hotline-deployment/pull/5