### PR TITLE
Increase UrgentCare resource quota to support hpa

### DIFF
--- a/products/urgent-care.yaml
+++ b/products/urgent-care.yaml
@@ -38,8 +38,8 @@ metadata:
   namespace: $DU_NAMESPACE
 spec:
   hard:
-    limits.cpu: "4500m"
-    limits.memory: "12G"
+    limits.cpu: "6000m"
+    limits.memory: "16G"
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy


### PR DESCRIPTION
Increased cpu/memory quota to support scaling out to max of 4 replicas under load stress.

Should be merged before https://github.com/department-of-veterans-affairs/health-apis-urgent-care-deployment/pull/33