### PR TITLE
Increased Squares resource quota to support hpa

### DIFF
--- a/products/squares.yaml
+++ b/products/squares.yaml
@@ -36,5 +36,5 @@ metadata:
   namespace: $DU_NAMESPACE
 spec:
   hard:
-    limits.cpu: "10000m"
-    limits.memory: "28G"
+    limits.cpu: "20000m"
+    limits.memory: "56G"


### PR DESCRIPTION
Increased cpu/memory quota to support scaling out to max of 4 replicas under load stress.

Should be merged before https://github.com/department-of-veterans-affairs/health-apis-squares-deployment/pull/5