### PR TITLE
Increased Community Care resource quota to support hpa

### DIFF
--- a/products/community-care.yaml
+++ b/products/community-care.yaml
@@ -42,5 +42,5 @@ metadata:
   namespace: $DU_NAMESPACE
 spec:
   hard:
-    limits.cpu: "6000m"
-    limits.memory: "9G"
+    limits.cpu: "7800m"
+    limits.memory: "12G"


### PR DESCRIPTION
Increased cpu/memory quota to support scaling out to max of 4 replicas under load stress.

Should be merged before https://github.com/department-of-veterans-affairs/health-apis-community-care-deployment/pull/30