### PR TITLE
Increased provider-directory resource quota for hpa

### DIFF
--- a/products/provider-directory.yaml
+++ b/products/provider-directory.yaml
@@ -38,5 +38,5 @@ metadata:
   namespace: $DU_NAMESPACE
 spec:
   hard:
-    limits.cpu: "6000m"
-    limits.memory: "9G"
+    limits.cpu: "7800m"
+    limits.memory: "12G"


### PR DESCRIPTION
Increased cpu/memory quota to support scaling out to max of 4 replicas under load stress.

Should be merged before https://github.com/department-of-veterans-affairs/health-apis-provider-directory-deployment/pull/10