### PR TITLE
Increased carma search resource quota for hpa

### DIFF
--- a/products/carma.yaml
+++ b/products/carma.yaml
@@ -36,5 +36,5 @@ metadata:
   namespace: $DU_NAMESPACE
 spec:
   hard:
-    limits.cpu: "1500m"
-    limits.memory: "7.5G"
+    limits.cpu: "2000m"
+    limits.memory: "10G"


### PR DESCRIPTION
Increased cpu/memory quota to support scaling out to max of 4 replicas under load stress.

Should be merged before https://github.com/department-of-veterans-affairs/health-apis-carma-search-deployment/pull/12