### PR TITLE
UC should still be taking well-known requests

### DIFF
--- a/products/urgent-care.yaml
+++ b/products/urgent-care.yaml
@@ -49,7 +49,7 @@ spec:
               serviceName: urgent-care-kong
               servicePort: 8082
 ---
-  # For Ad Hoc and anything else that needs access to metadata and openapi
+  # For Ad Hoc and anything else that needs access to metadata, openapi, or well known
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -62,7 +62,7 @@ spec:
   rules:
     - http:
         paths:
-          - path: /fhir/v0/r4/(metadata|openapi.*)
+          - path: /fhir/v0/r4/(metadata|openapi.*|.well-known/smart-configuration)
             backend:
               serviceName: urgent-care-kong
               servicePort: 8082


### PR DESCRIPTION
Well-Known requests for R4 currently have nowhere to go. They were removed from UC's ingress rules and there's no unifier set up yet to receive them.

https://api.va.gov/services/fhir/v0/r4/.well-known/smart-configuration