### PR TITLE
Split SSNSensitivity-VIMT from Hotline.

### DIFF
--- a/products/hotline.conf
+++ b/products/hotline.conf
@@ -1,6 +1,6 @@
 # HOTLINE Deployment Unit Configurations
 DU_ARTIFACT=health-apis-hotline-deployment
-DU_VERSION=1.0.26
+DU_VERSION=1.0.27
 DU_NAMESPACE=views-hotline
 DU_DECRYPTION_KEY="$DEPLOYMENT_CRYPTO_KEY"
 DU_HEALTH_CHECK_PATH="/patsr/whHotlineCase/healthz"
@@ -8,4 +8,3 @@ DU_PROPERTY_LEVEL_ENCRYPTION=true
 # ========================================
 DU_LOAD_BALANCER_RULES[820]="*/patsr/*"
 DU_LOAD_BALANCER_RULES[830]="*/sfdc/*"
-DU_LOAD_BALANCER_RULES[840]="*/vimt/*"

--- a/products/ssn-sensitivity-vimt.conf
+++ b/products/ssn-sensitivity-vimt.conf
@@ -1,0 +1,9 @@
+# SSN Sensitivity VIMT Deployment Unit Configurations
+DU_ARTIFACT=health-apis-ssn-sensitivity-vimt-deployment
+DU_VERSION=1.0.0
+DU_NAMESPACE=views-ssn-sensitivity-vimt
+DU_DECRYPTION_KEY="$DEPLOYMENT_CRYPTO_KEY"
+DU_HEALTH_CHECK_PATH="/vimt/SendReceive/healthz"
+DU_PROPERTY_LEVEL_ENCRYPTION=true
+# ========================================
+DU_LOAD_BALANCER_RULES[840]="*/vimt/*"

--- a/products/ssn-sensitivity-vimt.yaml
+++ b/products/ssn-sensitivity-vimt.yaml
@@ -27,7 +27,7 @@ spec:
           - path: /(api/)?(vimt)(.*)
             backend:
               serviceName: ssn-sensitivity-vimt
-              servicePort: 8091
+              servicePort: 8092
 ---
 apiVersion: v1
 kind: ResourceQuota

--- a/products/ssn-sensitivity-vimt.yaml
+++ b/products/ssn-sensitivity-vimt.yaml
@@ -10,7 +10,7 @@ metadata:
     deployment-date: $BUILD_DATE
     deployment-s3-bucket: $DU_AWS_BUCKET_NAME
     deployment-s3-folder: $DU_S3_FOLDER
-    deployment-app-version: $SALESFORCE_VERSION
+    deployment-app-version: $SSN_SENSITIVITY_VIMT_VERSION
     deployment-test-status: UNTESTED
 ---
 apiVersion: extensions/v1beta1

--- a/products/ssn-sensitivity-vimt.yaml
+++ b/products/ssn-sensitivity-vimt.yaml
@@ -16,7 +16,7 @@ metadata:
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: salesforce-ingress
+  name: ssn-sensitivity-vimt-ingress
   namespace: $DU_NAMESPACE
   annotations:
     kubernetes.io/ingress.class: nginx
@@ -24,15 +24,15 @@ spec:
   rules:
     - http:
         paths:
-          - path: /(api/)?(patsr|sfdc)(.*)
+          - path: /(api/)?(vimt)(.*)
             backend:
-              serviceName: salesforce
+              serviceName: ssn-sensitivity-vimt
               servicePort: 8091
 ---
 apiVersion: v1
 kind: ResourceQuota
 metadata:
-  name: views-hotline-resource-quota
+  name: views-ssn-sensitivity-vimt-resource-quota
   namespace: $DU_NAMESPACE
 spec:
   hard:


### PR DESCRIPTION
Splitting up hotline and ssn-sensitivity since they’re separate functionality and it should cut down on danger zone deployments.  Please see PIV-79 (and related stories) for additional context.