### PR TITLE
Ingress rule for testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,6 +28,7 @@ def products() {
   products["qms"] = ["health_apis_jenkins"]
   products["squares"] = ["health_apis_jenkins"]
   products["ssn-sensitivity-vimt"] = ["health_apis_jenkins"]
+  products["unifier-kong"] = ["health_apis_jenkins"]
   products["urgent-care"] = ["health_apis_jenkins"]
   products["watrs"] = ["health_apis_jenkins"]
   return products

--- a/products/unifier-kong.conf
+++ b/products/unifier-kong.conf
@@ -1,10 +1,10 @@
 # Conformance/Capability Statement Kong Deployment Unit Configurations
 DU_ARTIFACT=health-apis-unifier-kong-deployment
-DU_VERSION=1.0.7
+DU_VERSION=1.0.8
 DU_NAMESPACE=unifier-kong
 DU_DECRYPTION_KEY="$DEPLOYMENT_CRYPTO_KEY"
 DU_HEALTH_CHECK_PATH="/unifier/healthz"
 DU_PROPERTY_LEVEL_ENCRYPTION=true
 # ========================================
 DU_LOAD_BALANCER_RULES[720]="/unifier/*"
-DU_LOAD_BALANCER_RULES[730]="/unifier-test/*"
+DU_LOAD_BALANCER_RULES[500]="/unifier-test/*"

--- a/products/unifier-kong.conf
+++ b/products/unifier-kong.conf
@@ -1,0 +1,10 @@
+# Conformance/Capability Statement Kong Deployment Unit Configurations
+DU_ARTIFACT=health-apis-unifier-kong-deployment
+DU_VERSION=1.0.7
+DU_NAMESPACE=unifier-kong
+DU_DECRYPTION_KEY="$DEPLOYMENT_CRYPTO_KEY"
+DU_HEALTH_CHECK_PATH="/unifier/healthz"
+DU_PROPERTY_LEVEL_ENCRYPTION=true
+# ========================================
+DU_LOAD_BALANCER_RULES[720]="/unifier/*"
+DU_LOAD_BALANCER_RULES[730]="/unifier-test/*"

--- a/products/unifier-kong.yaml
+++ b/products/unifier-kong.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: $DU_NAMESPACE
+  labels:
+    deployment-id: $K8S_DEPLOYMENT_ID
+    deployment-unit: $PRODUCT
+    deployment-unit-artifact: $DU_ARTIFACT
+    deployment-unit-version: $DU_VERSION
+    deployment-date: $BUILD_DATE
+    deployment-s3-bucket: $DU_AWS_BUCKET_NAME
+    deployment-s3-folder: $DU_S3_FOLDER
+    deployment-app-version: $UNIFIER_VERSION
+    deployment-test-status: UNTESTED
+---
+#For health checks on the kong instance itself, but can be used for other future things
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: unifier-kong-general-ingress
+  namespace: $DU_NAMESPACE
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /unifier/(.*)
+            backend:
+              serviceName: unifier-kong
+              servicePort: 8082
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: unifier-kong-informational-ingress
+  namespace: $DU_NAMESPACE
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/rewrite-target: /$1/$2
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /unifier-test/(fhir/v0/.*)/(metadata|.well-known/smart-configuration)
+            backend:
+              serviceName: unifier-kong
+              servicePort: 8082


### PR DESCRIPTION
This also has an LB rule in the hopes we can deploy this up to PROD without danger zone builds the whole way. If that plan sounds good I need to get an accompanying PR approved real quick to prepend to the paths that we test with our test image.

Either way, after testing unifier in various environments we'd make a second deployer PR that:
* takes the unifier-test portion of the ingress rule out 
* adds the LB rules for UK
* edits the ingress rules for DQ and UC that handle metadata and well-known

We'd then need to redeploy UK to all environments as well as DQ and UC. The unifier-test LB rule should be taken away if it ends up being used.