### PR TITLE
Update DU version with prod -> production rename

### DIFF
--- a/products/unifier-kong.conf
+++ b/products/unifier-kong.conf
@@ -1,6 +1,6 @@
 # Conformance/Capability Statement Kong Deployment Unit Configurations
 DU_ARTIFACT=health-apis-unifier-kong-deployment
-DU_VERSION=1.0.8
+DU_VERSION=1.0.9
 DU_NAMESPACE=unifier-kong
 DU_DECRYPTION_KEY="$DEPLOYMENT_CRYPTO_KEY"
 DU_HEALTH_CHECK_PATH="/unifier/healthz"


### PR DESCRIPTION
Fixing issue where files were incorrectly named prod.conf and prod.testvars instead of production.conf and production.testvars for Unifier Kong DU