### PR TITLE
Add Specific AZ to carma-fms-connector

### DIFF
--- a/products/carma-fms-connector.conf
+++ b/products/carma-fms-connector.conf
@@ -2,6 +2,7 @@ DU_ARTIFACT=health-apis-carma-fms-connector-deployment
 DU_VERSION=1.0.30
 DU_NAMESPACE=carma-fms
 DU_DECRYPTION_KEY="$DEPLOYMENT_CRYPTO_KEY"
+DU_AUTOMATIC_AVAILABILITY_ZONES=a
 DU_HEALTH_CHECK_PATH="/carma-fms/v0/actuator/info"
 DU_PROPERTY_LEVEL_ENCRYPTION=true
 # ========================================


### PR DESCRIPTION
carma-fms-connector can currently only deploy to one AZ, adding the configuration for the deployer so we can have automatic deployments.