### PR TITLE
Added DU_AUTOMATIC_AZ settings for Pivot! applications.

### DIFF
--- a/products/email-to-case.conf
+++ b/products/email-to-case.conf
@@ -2,6 +2,7 @@ DU_ARTIFACT=health-apis-email-to-case-deployment
 DU_VERSION=1.0.9
 DU_NAMESPACE=email-to-case
 DU_DECRYPTION_KEY="$DEPLOYMENT_CRYPTO_KEY"
+DU_AUTOMATIC_AVAILABILITY_ZONES=a
 DU_HEALTH_CHECK_PATH="/email-to-case/v0/actuator/health"
 DU_PROPERTY_LEVEL_ENCRYPTION=true
 # ========================================

--- a/products/gal-processor.conf
+++ b/products/gal-processor.conf
@@ -2,6 +2,7 @@ DU_ARTIFACT=health-apis-gal-processor-deployment
 DU_VERSION=1.0.29
 DU_NAMESPACE=views-gal-processor
 DU_DECRYPTION_KEY="$DEPLOYMENT_CRYPTO_KEY"
+DU_AUTOMATIC_AVAILABILITY_ZONES=a
 DU_HEALTH_CHECK_PATH="/gal-processor/actuator/health"
 DU_PROPERTY_LEVEL_ENCRYPTION=true
 # ========================================

--- a/products/gal.conf
+++ b/products/gal.conf
@@ -2,6 +2,7 @@ DU_ARTIFACT=health-apis-gal-deployment
 DU_VERSION=1.0.19
 DU_NAMESPACE=views-gal
 DU_DECRYPTION_KEY="$DEPLOYMENT_CRYPTO_KEY"
+DU_AUTOMATIC_AVAILABILITY_ZONES=a
 DU_HEALTH_CHECK_PATH="/gal/healthz"
 DU_PROPERTY_LEVEL_ENCRYPTION=true
 # ========================================

--- a/products/qms.conf
+++ b/products/qms.conf
@@ -3,6 +3,7 @@ DU_ARTIFACT=health-apis-qms-deployment
 DU_VERSION=0.0.14
 DU_NAMESPACE=views-qms
 DU_DECRYPTION_KEY="$DEPLOYMENT_CRYPTO_KEY"
+DU_AUTOMATIC_AVAILABILITY_ZONES=a
 DU_HEALTH_CHECK_PATH="/qms/healthz"
 DU_PROPERTY_LEVEL_ENCRYPTION=true
 # ========================================

--- a/products/squares.conf
+++ b/products/squares.conf
@@ -3,6 +3,7 @@ DU_ARTIFACT=health-apis-squares-deployment
 DU_VERSION=1.0.29
 DU_NAMESPACE=views-squares
 DU_DECRYPTION_KEY="$DEPLOYMENT_CRYPTO_KEY"
+DU_AUTOMATIC_AVAILABILITY_ZONES=ab
 DU_HEALTH_CHECK_PATH="/squares/mvi/healthz"
 DU_PROPERTY_LEVEL_ENCRYPTION=true
 # ========================================

--- a/products/watrs.conf
+++ b/products/watrs.conf
@@ -3,6 +3,7 @@ DU_ARTIFACT=health-apis-watrs-deployment
 DU_VERSION=0.0.27
 DU_NAMESPACE=views-watrs
 DU_DECRYPTION_KEY="$DEPLOYMENT_CRYPTO_KEY"
+DU_AUTOMATIC_AVAILABILITY_ZONES=a
 DU_HEALTH_CHECK_PATH="/watrs/healthz"
 DU_PROPERTY_LEVEL_ENCRYPTION=true
 # ========================================


### PR DESCRIPTION
Added `DU_AUTOMATIC_AVAILABILITY_ZONES` setting per PIV-228.
https://vasdvp.atlassian.net/browse/PIV-228

Deployer `{product}.conf` updated for any Pivot! owned integrations including:
- GAL (Only one AZ, A)
- GAL-PROCESSOR (Same as above)
- SQUARES (AZs A and B only)
- QMS (Only one AZ, A)
- WATRS (Only one AZ, A)