### PR TITLE
SFDC-MVI-ENT DU Probe changes

### DIFF
--- a/products/sfdc-mvi-ent.conf
+++ b/products/sfdc-mvi-ent.conf
@@ -3,6 +3,7 @@ DU_ARTIFACT=health-apis-sfdc-mvi-ent-deployment
 DU_VERSION=1.0.54
 DU_NAMESPACE=sfdc-mvi-ent
 DU_DECRYPTION_KEY="$DEPLOYMENT_CRYPTO_KEY"
+DU_AUTOMATIC_AVAILABILITY_ZONES=ab
 DU_HEALTH_CHECK_PATH="/sfdc-mvi-ent/v0/actuator/info"
 DU_PROPERTY_LEVEL_ENCRYPTION=true
 # =========================================

--- a/products/sfdc-mvi-ent.conf
+++ b/products/sfdc-mvi-ent.conf
@@ -1,6 +1,6 @@
 # sfdc mvi enterprise app
 DU_ARTIFACT=health-apis-sfdc-mvi-ent-deployment
-DU_VERSION=1.0.53
+DU_VERSION=1.0.54
 DU_NAMESPACE=sfdc-mvi-ent
 DU_DECRYPTION_KEY="$DEPLOYMENT_CRYPTO_KEY"
 DU_HEALTH_CHECK_PATH="/sfdc-mvi-ent/v0/actuator/info"


### PR DESCRIPTION
Liveliness and readiness probes are now to use `/actuator/health` rather than `/actuator/info`