### PR TITLE
Api 2196 ryan secrets openssl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@
 *~
 
 # Residuals from building the toolkit
-toolkit-base/.jenkins_unstable
+toolkit-base/
+.jenkins_unstable
 
 # IntelliJ idea files
 .idea

--- a/bin/ryan-secrets
+++ b/bin/ryan-secrets
@@ -32,12 +32,12 @@ encryptAll() {
 
 secret() {
   local secret="$@"
-  echo -E "$secret" | openssl enc -aes-256-cbc -a -A -nosalt -k "$ENCRYPTION_PASSPHRASE"
+  echo -E "$secret" | openssl enc -aes-256-cbc -md md5 -a -A -nosalt -k "$ENCRYPTION_PASSPHRASE" 2> /dev/null
 }
 
 unsecret() {
   local secret="$@"
-  echo -E "$secret" | openssl enc -aes-256-cbc -d -a -A -nosalt -k "$ENCRYPTION_PASSPHRASE"
+  echo -E "$secret" | openssl enc -aes-256-cbc -md md5 -d -a -A -nosalt -k "$ENCRYPTION_PASSPHRASE" 2> /dev/null
 }
 
 encrypt() {

--- a/toolkit/build-toolkit.sh
+++ b/toolkit/build-toolkit.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
 
+cd $(dirname $0)
+
 ./../toolkit-base/build-toolkit-base.sh
 docker build --no-cache -t vasdvp/deployer-toolkit:latest . -f Dockerfile.toolkit


### PR DESCRIPTION
Fixes issue during deployment:
```
*** WARNING : deprecated key derivation used.
Using -iter or -pbkdf2 would be better.
```

Determined to be caused by the update of the `openssl` command in centos8