### PR TITLE
actuator rewrite is unecessary removing it

### DIFF
--- a/products/auth.yaml
+++ b/products/auth.yaml
@@ -29,21 +29,3 @@ spec:
             backend:
               serviceName: auth
               servicePort: 8082
----
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: auth-actuator-ingress
-  namespace: $DU_NAMESPACE
-  annotations:
-    kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/rewrite-target: /actuator/$1
-spec:
-  rules:
-    - http:
-        paths:
-          - path: /auth/actuator/(.*)
-            backend:
-              serviceName: auth
-              servicePort: 8082
-


### PR DESCRIPTION
Context Root was preserved for actuator endpoints. had to remove the actuator rewrites which assumed the context root would not be preserved.