### PR TITLE
Revert "API-3881 strip services from PGD path"

### DIFF
--- a/ingress.tests
+++ b/ingress.tests
@@ -133,7 +133,6 @@ nurse-triage /nt-ent/actuator/info
 patient-generated-data /patient-generated-data/actuator/health
 patient-generated-data /pgd/v0/r4/Observation?patient=1010101010V666666
 patient-generated-data /pgd/v0/r4/openapi.json
-patient-generated-data /services/pgd/v0/r4/openapi.json
 # Patsr
 patsr /whh-patsr-ent/actuator/health
 patsr /whh-patsr-ent/actuator/info

--- a/products/patient-generated-data.yaml
+++ b/products/patient-generated-data.yaml
@@ -21,12 +21,12 @@ metadata:
   namespace: $DU_NAMESPACE
   annotations:
     kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
 spec:
   rules:
     - http:
         paths:
-          - path: /(services/|)pgd/v0/(.*)
+          - path: /pgd/v0/(.*)
             backend:
               serviceName: health-apis-kong
               servicePort: 8082


### PR DESCRIPTION
Is this a new product? no

Has this been deployed successfully from a branch? yes

Are load balancer rules being removed or renamed? no

Are ingress definitions being removed or renamed? yes

Are Kubernetes namespaces being removed or renamed? no

Has DevOps been consulted on resource limits? n/a

revert https://github.com/department-of-veterans-affairs/health-apis-deployer/pull/442