### PR TITLE
API-5280 smart cards external load balancer rules

### DIFF
--- a/products/smart-cards.conf
+++ b/products/smart-cards.conf
@@ -5,4 +5,6 @@ DU_DECRYPTION_KEY="$DEPLOYMENT_CRYPTO_KEY"
 DU_HEALTH_CHECK_PATH="/smart-cards/actuator/health"
 DU_PROPERTY_LEVEL_ENCRYPTION=true
 # ========================================
+DU_LOAD_BALANCER_RULES[100]="/fhir/v0/r4/Patient/*/\$HealthWallet.issueVc"
+DU_LOAD_BALANCER_RULES[110]="/fhir/v0/dstu2/Patient/*/\$HealthWallet.issueVc"
 DU_LOAD_BALANCER_RULES[860]="/smart-cards/*"


### PR DESCRIPTION
Dedicated load-balancer rules for smart cards.
`https://blue.qa.lighthouse.va.gov/fhir/v0/r4/Patient/123/$HealthWallet.issueVc` is accessible
`https://green.qa.lighthouse.va.gov/fhir/v0/r4/Patient/123/$HealthWallet.issueVc` is not

Is this a new product? no

Has this been deployed successfully from a branch? yes

Are load balancer rules being removed or renamed? yes

Are ingress definitions being removed or renamed? no

Are Kubernetes namespaces being removed or renamed? no

Has DevOps been consulted on resource limits? n/a